### PR TITLE
Feature: MIDI alternative mappings when FN key held

### DIFF
--- a/json_objects/midi_action_mapping.json
+++ b/json_objects/midi_action_mapping.json
@@ -1,7 +1,8 @@
 {
     "control_change 0": {
 		"DEFAULT": ["set_the_shader_param_0_layer_offset_0_continuous"],
-        "NAV_DETOUR": ["set_detour_mix_continuous"]
+        "NAV_DETOUR": ["set_detour_mix_continuous"],
+		"FN_DEFAULT": ["set_strobe_amount_continuous"]
 	},
     "control_change 1": {
 		"DEFAULT": ["set_the_shader_param_1_layer_offset_0_continuous"],

--- a/user_input/midi_input.py
+++ b/user_input/midi_input.py
@@ -98,7 +98,7 @@ class MidiInput(object):
         if 'control' in message_dict:
             mapped_message_name = '{} {}'.format(mapped_message_name,message_dict['control'])
             mapped_message_value = message_dict['value']
-        
+
         if mapped_message_name in self.midi_mappings.keys():
             self.run_action_for_mapped_message(mapped_message_name, mapped_message_value)
         else:
@@ -106,8 +106,12 @@ class MidiInput(object):
 
     def run_action_for_mapped_message(self, message_name, mapped_message_value):
         this_mapping = self.midi_mappings[message_name]
-        if self.data.control_mode in this_mapping:
+        if self.data.function_on and "FN_%s"%self.data.control_mode in this_mapping:
+            mode = "FN_%s"%self.data.control_mode
+        elif self.data.control_mode in this_mapping:
             mode = self.data.control_mode
+        elif self.data.function_on and "FN_DEFAULT" in this_mapping:
+            mode = "FN_DEFAULT"
         elif 'DEFAULT' in this_mapping:
             mode = 'DEFAULT'
 


### PR DESCRIPTION
Can now add alternative mappings for when FN key is held, other mappings fall back to non-FN versions if nothing mapped.

Think this basically lets you implement suggestion 2 of #99 in your MIDI mapping config.  Updated the default MIDI mapping to put set_strobe on the FN+MIDI CC0 control as an example.