### PR TITLE
Couple of small tweaks to latest dev

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -1,8 +1,8 @@
 # Auto-generated Actions list
 
-Fri 3 Jan 22:08:36 UTC 2020
+Sat 29 Feb 12:43:41 UTC 2020
 
-for branch=feature_shader_midi
+for branch=dev
 
 # Methods
   *   change_composite_setting(setting_value)
@@ -30,6 +30,7 @@ for branch=feature_shader_midi
   *   decrease_speed
   *   decrease_this_param
   *   disable_feedback
+  *   eject_all_usb_drives
   *   enable_feedback
   *   enter_on_browser_selection
   *   enter_on_settings_selection
@@ -59,10 +60,16 @@ for branch=feature_shader_midi
   *   _load_this_slot_into_next_player(slot)
   *   map_on_shaders_selection
   *   move_browser_selection_down
+  *   move_browser_selection_page_down
+  *   move_browser_selection_page_up
   *   move_browser_selection_up
   *   move_settings_selection_down
+  *   move_settings_selection_page_down
+  *   move_settings_selection_page_up
   *   move_settings_selection_up
   *   move_shaders_selection_down
+  *   move_shaders_selection_page_down
+  *   move_shaders_selection_page_up
   *   move_shaders_selection_up
   *   next_bank
   *   next_shader_layer
@@ -124,6 +131,7 @@ for branch=feature_shader_midi
   *   set_the_shader_param_3_layer_offset_2_continuous(amount)
   *   set_the_shader_param_3_layer_offset_3_continuous(amount)
   *   shutdown_pi
+  *   stop_remote_process
   *   switch_conjur_player_type(value)
   *   switch_dev_mode(state)
   *   switch_display_to_hdmi
@@ -135,6 +143,8 @@ for branch=feature_shader_midi
   *   switch_to_next_player
   *   switch_to_this_detour(number)
   *   switch_video_backend(state)
+  *   toggle_access_point_delay(setting_value, osc_setting_state )
+  *   toggle_access_point(setting_value)
   *   toggle_action_on_player
   *   toggle_capture_preview
   *   toggle_capture_recording

--- a/actions.py
+++ b/actions.py
@@ -725,6 +725,7 @@ class Actions(object):
 
 
     def quit_the_program(self):
+        self.data._update_json(self.data.SETTINGS_JSON, self.data.settings)
         self.video_driver.exit_all_players()
         self.exit_openframeworks()
         self.exit_osc_server('','')

--- a/data_centre/data.py
+++ b/data_centre/data.py
@@ -69,11 +69,12 @@ class Data(object):
         self.shader_bank_data = [self.create_empty_shader_bank() for i in range(3)]
         if os.path.isfile(self.PATH_TO_DATA_OBJECTS + self.SHADER_BANK_DATA_JSON):
             self.shader_bank_data = self._read_json(self.SHADER_BANK_DATA_JSON)
-        self.settings = self._read_json(self.DEFAULT_SETTINGS_JSON)
+        self.settings = self.default_settings = self._read_json(self.DEFAULT_SETTINGS_JSON)
 
         if os.path.isfile(self.PATH_TO_DATA_OBJECTS + self.SETTINGS_JSON):
             self.settings = self._read_json(self.SETTINGS_JSON)
-            self.settings['user_input']['REMOTE_SERVER']['value'] = 'disabled' # remote server off at boot
+            self.settings['user_input'].setdefault('REMOTE_SERVER',
+                    self.default_settings['user_input']['REMOTE_SERVER'])['value'] = 'disabled' # remote server off at boot
 
         self.key_mappings = self._read_json(self.KEYPAD_MAPPING_JSON)
         self.osc_mappings = self._read_json(self.OSC_MAPPING_JSON)

--- a/data_centre/data.py
+++ b/data_centre/data.py
@@ -69,7 +69,8 @@ class Data(object):
         self.shader_bank_data = [self.create_empty_shader_bank() for i in range(3)]
         if os.path.isfile(self.PATH_TO_DATA_OBJECTS + self.SHADER_BANK_DATA_JSON):
             self.shader_bank_data = self._read_json(self.SHADER_BANK_DATA_JSON)
-        self.settings = self.default_settings = self._read_json(self.DEFAULT_SETTINGS_JSON)
+        self.settings = self._read_json(self.DEFAULT_SETTINGS_JSON)
+        self.default_settings = self.settings.copy()
 
         if os.path.isfile(self.PATH_TO_DATA_OBJECTS + self.SETTINGS_JSON):
             self.settings = self._read_json(self.SETTINGS_JSON)

--- a/dotfiles/generate-list-actions.sh
+++ b/dotfiles/generate-list-actions.sh
@@ -8,7 +8,7 @@ echo
 
 echo "# Methods"
 grep " def " actions.py | grep -v "^#" | sed -e 's/ def //' | sed -e 's/self//' | sed -e 's/(, /(/' | sed -e 's/()//' | sed -e 's/\(.*\)/  *\1/' | sed -e 's/://' | sort -n \
-	| grep -v "parserlist\|check_if_should_start_openframeworks\|create_serial_port_process\|__init__\|persist_composite_setting\|receive_detour_info\|_refresh_frame_buffer\|refresh_frame_buffer_and_restart_openframeworks\|run_script\|setup_osc_server\|start_confirm_action\|stop_serial_port_process\|stop_openframeworks_process\|update_capture_settings\|update_config_settings\|update_video_settings\|try_remove_file\|get_callback\|call_method_name\|call_parse_method\|detect_types"
+	| grep -v "parserlist\|check_if_should_start_openframeworks\|create_serial_port_process\|__init__\|persist_composite_setting\|receive_detour_info\|_refresh_frame_buffer\|refresh_frame_buffer_and_restart_openframeworks\|run_script\|setup_osc_server\|start_confirm_action\|stop_serial_port_process\|stop_openframeworks_process\|update_capture_settings\|update_config_settings\|update_video_settings\|try_remove_file\|get_callback\|call_method_name\|call_parse_method\|detect_types\|show_ip\|toggle_remote_server\|enable_osc\|shutdown_osc_server"
 echo
 
 echo  "# Dynamic routes"

--- a/user_input/numpad_input.py
+++ b/user_input/numpad_input.py
@@ -36,7 +36,9 @@ class NumpadInput(object):
                 self.check_key_release_settings(event.char)
 
     def on_mouse_move(self, event):
-        if self.data.settings['user_input']['MOUSE_INPUT']['value'] != 'enabled':
+        if self.data.settings['user_input'].setdefault(
+                'MOUSE_INPUT',
+                self.data.default_settings.get('MOUSE_INPUT',{'value': 'enabled'})).get('value') != 'enabled':
             return
         if event.x > 480 or event.y > 320:
             return

--- a/user_input/numpad_input.py
+++ b/user_input/numpad_input.py
@@ -61,9 +61,9 @@ class NumpadInput(object):
             
         print('the action being called is {}'.format(this_mapping[mode][is_function]))
         if value != -1:
-            self.actions.call_method_name(this_mapping[mode][is_function])(value)
+            self.actions.call_method_name(this_mapping[mode][is_function],value)
         else:
-            self.actions.call_method_name(this_mapping[mode][is_function])()
+            self.actions.call_method_name(this_mapping[mode][is_function])
 
         if is_function and self.data.settings['sampler']['FUNC_GATED']['value'] == 'off':
             self.data.function_on = False

--- a/user_input/numpad_input.py
+++ b/user_input/numpad_input.py
@@ -61,9 +61,9 @@ class NumpadInput(object):
             
         print('the action being called is {}'.format(this_mapping[mode][is_function]))
         if value != -1:
-            getattr(self.actions, this_mapping[mode][is_function])(value)
+            self.actions.call_method_name(this_mapping[mode][is_function])(value)
         else:
-            getattr(self.actions, this_mapping[mode][is_function])()
+            self.actions.call_method_name(this_mapping[mode][is_function])()
 
         if is_function and self.data.settings['sampler']['FUNC_GATED']['value'] == 'off':
             self.data.function_on = False

--- a/user_input/osc_input.py
+++ b/user_input/osc_input.py
@@ -23,6 +23,8 @@ class OscInput(object):
         self.poll_settings_for_osc_info()
 
     def poll_settings_for_osc_info(self):
+        self.data.settings['user_input'].setdefault('OSC_INPUT',
+                self.data.default_settings['user_input'].get('OSC_INPUT'))
         osc_setting_enabled = self.data.settings['user_input']['OSC_INPUT']['value'] == 'enabled'
         if osc_setting_enabled and not self.osc_enabled:
             self.setup_osc_server()

--- a/user_input/osc_input.py
+++ b/user_input/osc_input.py
@@ -34,6 +34,7 @@ class OscInput(object):
         this_dispatcher.map("/shaderparam2", self.on_param_osc_input)
         this_dispatcher.map("/shaderparam3", self.on_param_osc_input)
         this_dispatcher.map("/shutdown", self.exit_osc_server)
+        this_dispatcher.map("/*", self.on_param_osc_input)
         
         server = osc_server.ThreadingOSCUDPServer((server_args.ip, server_args.port), this_dispatcher)
         server_thread = threading.Thread(target=server.serve_forever)

--- a/video_centre/shaders.py
+++ b/video_centre/shaders.py
@@ -20,10 +20,15 @@ class Shaders(object):
         self.selected_speed_list = [1.0, 1.0, 1.0]
 
         self.selected_modulation_slot = 0
-        self.selected_modulation_level = [[[0.0,0.0,0.0,0.0] for i in range(4)] for i in range(3)]
+        #self.modulation_level = [[[0.0,0.0,0.0,0.0] for i in range(4)] for i in range(3)]
         self.modulation_value = [0.0,0.0,0.0,0.0]
 
         #self.load_selected_shader()
+
+    @property
+    def modulation_level(self):
+        return self.data.settings['shader'].setdefault('modulation_level', 
+                [[[0.0,0.0,0.0,0.0] for i in range(4)] for i in range(3)])
 
     def generate_shaders_list(self):
         shaders_menu_list = []
@@ -163,7 +168,7 @@ class Shaders(object):
         self.selected_modulation_slot = slot
 
     def reset_modulation(self, slot):
-        for layer in self.selected_modulation_level:
+        for layer in self.modulation_level:
             for layer,levels in enumerate(layer):
                 levels[slot] = 0.0
 
@@ -224,7 +229,7 @@ class Shaders(object):
         self.modulation_value[param] = (value-0.5)*2
         for layer,params in enumerate(self.selected_param_list):
           for ip,p in enumerate(params):
-              for p2,v in enumerate(self.selected_modulation_level[layer][ip]):
+              for p2,v in enumerate(self.modulation_level[layer][ip]):
                   if v!=0:
                       self.update_param_layer(ip,layer)
                       break
@@ -234,7 +239,7 @@ class Shaders(object):
         self.set_param_layer_modulation_level(param, layer, level)
 
     def set_param_layer_modulation_level(self, param, layer, level):
-        self.selected_modulation_level[layer][param][self.selected_modulation_slot] = level
+        self.modulation_level[layer][param][self.selected_modulation_slot] = level
         self.update_param_layer(param, layer)
 
     def update_param_layer(self, param, layer):
@@ -244,7 +249,7 @@ class Shaders(object):
                 self.get_modulation_value_list(
                     self.selected_param_list[layer][param],
                     self.modulation_value,#[0], #param],
-                    self.selected_modulation_level[layer][param]
+                    self.modulation_level[layer][param]
                 )
         )
 

--- a/video_centre/shaders.py
+++ b/video_centre/shaders.py
@@ -1,6 +1,6 @@
 import display_centre.menu as menu
 import os
-
+from statistics import mean
 
 class Shaders(object):
     MENU_HEIGHT = 10
@@ -202,7 +202,6 @@ class Shaders(object):
         for i,v in enumerate(values):
             l.append(self.get_modulation_value(amount, v, levels[i]))
 
-        from statistics import mean
         #print ("got mean %s from amount %s with %s*%s" % (mean(l), amount, values, levels))
         return mean(l)
 


### PR DESCRIPTION
 - enable numpad input to use the 'dynamic' actions (and hence plugins when merged with plugins branch)
 - generated new ACTIONS.md text
 - don't barf if REMOTE_SERVER settings aren't found in the config -- fallback to default config
 - osc input listens to generic routes again (is so external osc sent over network can be routed in to control r_e_c_u_r - maybe want to make this optional?)
 - save settings json on quit
 - saves shader modulation settings in settings json so they persist across restarts