### PR TITLE
Update analog_input.py

### DIFF
--- a/user_input/analog_input.py
+++ b/user_input/analog_input.py
@@ -45,7 +45,7 @@ class AnalogInput(object):
                     if abs(this_reading - self.last_readings[i]) > 10:
                         #print('the diff is {}'.format(this_reading - self.last_readings[i]))
                         self.run_action_for_mapped_channel(i, this_reading)
-                    self.last_readings[i] = this_reading
+                        self.last_readings[i] = this_reading
             self.root.after(self.analog_delay, self.poll_analog_inputs)
         else:
             self.check_if_listening_enabled()


### PR DESCRIPTION
Changed indentation. The last_readings value should only be updated when the deadband has been exceeded. Otherwise turning the pot very slowly will NOT change the shader value but once the pot is turned faster, the value will suddenly jump to the pot position

At least that is what I like to believe, cheers

<img width="1407" height="1080" alt="Screenshot_2026-02-14_01-07-15" src="https://github.com/user-attachments/assets/18a772ca-3ae7-4102-b146-0857c7c3aeea" />
